### PR TITLE
Principal Variation.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -38,7 +38,7 @@ SearchInfo::SearchInfo() {
 }
 
 SearchInfo::SearchInfo(int _depth, int _seldepth, bool _is_mate, float _score, int _nodes, int _nps,
-        double _time, Move _move, float _alpha, float _beta) {
+        double _time, vector<Move> _pv, float _alpha, float _beta) {
     depth = _depth;
     seldepth = _seldepth;
     is_mate_score = _is_mate;
@@ -46,7 +46,7 @@ SearchInfo::SearchInfo(int _depth, int _seldepth, bool _is_mate, float _score, i
     nodes = _nodes;
     nps = _nps;
     time = _time;
-    move = _move;
+    pv = _pv;
     alpha = _alpha;
     beta = _beta;
 }
@@ -59,7 +59,8 @@ string SearchInfo::as_string() {
     str += " " + std::to_string((is_mate_score ? (int)score : (int)(100*score)));
     str += " nodes " + std::to_string(nodes) + " nps " + std::to_string(nps);
     str += " tbhits 0 time " + std::to_string((int)(1000*time));
-    str += " pv " + Bitboard::move_str(move);
+    str += " pv ";
+    for (const auto& move: pv) str += Bitboard::move_str(move) + " ";
     return str;
 }
 
@@ -104,11 +105,12 @@ SearchInfo dfs(const Options& options, const Position& pos, const int& depth, fl
             options.hash_evaled[idx] = true;
             options.hash_evals[idx] = score;
         }
-        return SearchInfo(depth, depth, false, score, 1, 0, 0, Move(), alpha, beta);
+        return SearchInfo(depth, depth, false, score, 1, 0, 0, {}, alpha, beta);
     }
     int nodes = 1;
     int best_ind = 0;
     float best_eval = pos.turn ? MIN : MAX;
+    vector<Move> pv;
 
     for (auto i = 0; i < moves.size(); i++) {
         Position new_pos = Bitboard::push(pos, moves[i]);
@@ -124,6 +126,7 @@ SearchInfo dfs(const Options& options, const Position& pos, const int& depth, fl
             if (result.score > best_eval) {
                 best_ind = i;
                 best_eval = result.score;
+                pv = result.pv;
             }
             if (result.score > alpha) alpha = result.score;
             if (beta <= alpha) break;
@@ -131,12 +134,14 @@ SearchInfo dfs(const Options& options, const Position& pos, const int& depth, fl
             if (result.score < best_eval) {
                 best_ind = i;
                 best_eval = result.score;
+                pv = result.pv;
             }
             if (result.score < beta) beta = result.score;
             if (beta <= alpha) break;
         }
     }
-    return SearchInfo(depth, depth, false, best_eval, nodes, 0, 0, moves[best_ind], alpha, beta);
+    pv.insert(pv.begin(), moves[best_ind]);
+    return SearchInfo(depth, depth, false, best_eval, nodes, 0, 0, pv, alpha, beta);
 }
 
 SearchInfo search(const Options& options, const Position& pos, const int& depth) {

--- a/src/search.hpp
+++ b/src/search.hpp
@@ -33,7 +33,7 @@ using std::string;
 
 struct SearchInfo {
     SearchInfo();
-    SearchInfo(int, int, bool, float, int, int, double, Move, float, float);
+    SearchInfo(int, int, bool, float, int, int, double, vector<Move>, float, float);
     string as_string();
 
     int depth;
@@ -43,7 +43,7 @@ struct SearchInfo {
     int nodes;
     int nps;
     double time;
-    Move move;
+    vector<Move> pv;
     float alpha;
     float beta;
 };

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -129,7 +129,7 @@ float go(Options& options, Position& pos, vector<string> parts, float prev_eval)
 
     SearchInfo result = search(options, pos, depth);
 
-    cout << "bestmove " << Bitboard::move_str(result.move) << endl;
+    cout << "bestmove " << Bitboard::move_str(result.pv[0]) << endl;
 
     chat(options, pos.turn, pos.move_stack.size(), result.score, prev_eval);
     return result.score;


### PR DESCRIPTION
## Describe changes
The `SearchInfo` struct contains a `vector<Move>` instead of `Move`. This allows it to store principal variations.

## Additional info
About 1% slower.