### PR TITLE
Move Ordering

### DIFF
--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -25,7 +25,6 @@
 #include <tuple>
 #include "bitboard.hpp"
 #include "utils.hpp"
-#include "options.hpp"
 #include "hash.hpp"
 
 using std::abs;

--- a/src/bitboard.hpp
+++ b/src/bitboard.hpp
@@ -23,7 +23,6 @@
 #include <vector>
 #include <tuple>
 #include <string>
-#include "options.hpp"
 
 using std::cin;
 using std::cout;

--- a/src/bitboard.hpp
+++ b/src/bitboard.hpp
@@ -124,6 +124,7 @@ namespace Bitboard {
 
     constexpr U64 BYTE_ALL_ONE = 255ULL;
     constexpr int MAX_MOVES = 120;
+    constexpr int MAX_HASH_MOVES = 30;
 
     constexpr char DIR_R_SIZE = 4;
     constexpr char DIR_N_SIZE = 8;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -58,6 +58,6 @@ Options::Options() {
 
 void Options::set_hash() {
     delete[] hash_table;
-    hash_size = Hash * 100000;
+    hash_size = Hash * 8520;
     hash_table = new MoveOrder[hash_size];
 }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -29,6 +29,11 @@ using std::vector;
 using std::string;
 
 
+MoveOrder::MoveOrder() {
+    computed = false;
+}
+
+
 Options::Options() {
     Hash = 16;
     UseHashTable = false;
@@ -52,14 +57,7 @@ Options::Options() {
 }
 
 void Options::set_hash() {
-    delete hash_evaled;
-    delete hash_evals;
-    hash_size = Hash * 125000;
-
-    hash_evaled = new bool[hash_size];
-    hash_evals = new float[hash_size];
-    for (int i = 0; i < hash_size; i++) {
-        hash_evaled[i] = false;
-        hash_evals[i] = 0;
-    }
+    delete[] hash_table;
+    hash_size = Hash * 50000;
+    hash_table = new MoveOrder[hash_size];
 }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -36,7 +36,8 @@ MoveOrder::MoveOrder() {
 
 Options::Options() {
     Hash = 256;
-    UseHashTable = false;
+    UseHashTable = true;
+    HashStart = 3;
 
     ABPassStart = 5;
     ABPassMargin = 500;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -58,6 +58,6 @@ Options::Options() {
 
 void Options::set_hash() {
     delete[] hash_table;
-    hash_size = Hash * 50000;
+    hash_size = Hash * 100000;
     hash_table = new MoveOrder[hash_size];
 }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -35,7 +35,7 @@ MoveOrder::MoveOrder() {
 
 
 Options::Options() {
-    Hash = 16;
+    Hash = 256;
     UseHashTable = false;
 
     ABPassStart = 5;

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -35,7 +35,7 @@ struct MoveOrder {
 
     bool computed;
     char movecnt;
-    Move moves[Bitboard::MAX_MOVES];
+    Move moves[Bitboard::MAX_HASH_MOVES];
 };
 
 class Options {

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -34,7 +34,7 @@ struct MoveOrder {
     MoveOrder();
 
     bool computed;
-    int movecnt;
+    char movecnt;
     Move moves[Bitboard::MAX_MOVES];
 };
 

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -22,12 +22,21 @@
 #include <iostream>
 #include <vector>
 #include <string>
+#include "bitboard.hpp"
 
 using std::cin;
 using std::cout;
 using std::endl;
 using std::vector;
 using std::string;
+
+struct MoveOrder {
+    MoveOrder();
+
+    bool computed;
+    int movecnt;
+    Move moves[Bitboard::MAX_MOVES];
+};
 
 class Options {
 /*
@@ -53,8 +62,7 @@ public:
     Options();
     void set_hash();
 
-    bool* hash_evaled = new bool[16];
-    float* hash_evals = new float[16];
+    MoveOrder* hash_table;
     int hash_size;
 
     int Hash;

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -41,7 +41,8 @@ struct MoveOrder {
 class Options {
 /*
 Hash: type=spin, default=16, min=1, max=65536, hash table size (megabytes)
-UseHashTable: type=check, default=false, whether the engine should use hash table.
+UseHashTable: type=check, default=true, whether the engine should use hash table.
+HashStart: type=spin, default=3, min=1, max=6, starting depth to read and write into hash table.
 
 ABPassStart: type=spin, default=5, min=1, max=100, start depth where alpha and beta values are passed to next iteration.
 ABPassMargin: type=spin, default=500, min=0, max=10000, add/sub offset of alpha and beta.
@@ -67,6 +68,7 @@ public:
 
     int Hash;
     bool UseHashTable;
+    int HashStart;
 
     int ABPassStart;
     int ABPassMargin;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -110,13 +110,12 @@ namespace Search {
         const U64 idx = Hash::hash(pos) % options.hash_size;
         const U64 o_attacks = Bitboard::attacked(pos, !pos.turn);
         const bool computed = options.hash_table[idx].computed;
-        vector<Move> moves;
+        vector<Move> moves = Bitboard::legal_moves(pos, o_attacks);
         vector<MoveEval> results;
-        if (computed) {
+        if (computed && moves.size() < Bitboard::MAX_HASH_MOVES) {
             const MoveOrder entry = options.hash_table[idx];
             moves = vector<Move>(entry.moves, entry.moves+entry.movecnt);
         }
-        else moves = Bitboard::legal_moves(pos, o_attacks);
 
         if (depth == 0 || moves.empty()) {
             const float score = Eval::eval(options, pos, moves, depth, o_attacks);
@@ -167,7 +166,7 @@ namespace Search {
 
         // Sort moves
         const char movecnt = moves.size();
-        if (depth >= 2 && movecnt <= Bitboard::MAX_MOVES && !options.hash_table[idx].computed) {
+        if (depth >= 3 && movecnt <= Bitboard::MAX_HASH_MOVES && !options.hash_table[idx].computed) {
             if (pos.turn) std::sort(results.begin(), results.end(), [](MoveEval x, MoveEval y){return x.second > y.second;});
             else std::sort(results.begin(), results.end(), [](MoveEval x, MoveEval y){return x.second < y.second;});
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -112,7 +112,7 @@ namespace Search {
         const bool computed = options.hash_table[idx].computed;
         vector<Move> moves = Bitboard::legal_moves(pos, o_attacks);
         vector<MoveEval> results;
-        if (computed && moves.size() < Bitboard::MAX_HASH_MOVES) {
+        if (options.UseHashTable && computed && moves.size() < Bitboard::MAX_HASH_MOVES) {
             const MoveOrder entry = options.hash_table[idx];
             moves = vector<Move>(entry.moves, entry.moves+entry.movecnt);
         }
@@ -166,7 +166,8 @@ namespace Search {
 
         // Sort moves
         const char movecnt = moves.size();
-        if (depth >= 3 && movecnt <= Bitboard::MAX_HASH_MOVES && !options.hash_table[idx].computed) {
+        if (options.UseHashTable && depth >= options.HashStart &&
+                movecnt <= Bitboard::MAX_HASH_MOVES && !options.hash_table[idx].computed) {
             if (pos.turn) std::sort(results.begin(), results.end(), [](MoveEval x, MoveEval y){return x.second > y.second;});
             else std::sort(results.begin(), results.end(), [](MoveEval x, MoveEval y){return x.second < y.second;});
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -103,8 +103,14 @@ namespace Search {
 
     SearchInfo dfs(const Options& options, const Position& pos, const int& depth, float alpha, float beta,
             const bool& root, const double& endtime, bool& searching) {
-        U64 o_attacks = Bitboard::attacked(pos, !pos.turn);
-        vector<Move> moves = Bitboard::legal_moves(pos, o_attacks);
+        const U64 idx = Hash::hash(pos) % options.hash_size;
+        const U64 o_attacks = Bitboard::attacked(pos, !pos.turn);
+        vector<Move> moves;
+        if (options.hash_table[idx].computed) {
+            const MoveOrder entry = options.hash_table[idx];
+            moves = vector<Move>(entry.moves, entry.moves+entry.movecnt);
+        }
+        else moves = Bitboard::legal_moves(pos, o_attacks);
 
         if (depth == 0 || moves.empty()) {
             const float score = Eval::eval(options, pos, moves, depth, o_attacks);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -107,15 +107,6 @@ namespace Search {
         vector<Move> moves = Bitboard::legal_moves(pos, o_attacks);
 
         if (depth == 0 || moves.empty()) {
-            // const int idx = options.UseHashTable ? (Hash::hash(pos) % options.hash_size) : 0;
-            // float score;
-            // if (options.UseHashTable && options.hash_evaled[idx]) {
-            //     score = options.hash_evals[idx];
-            // } else {
-            //     score = eval(options, pos, moves, depth, o_attacks);
-            //     options.hash_evaled[idx] = true;
-            //     options.hash_evals[idx] = score;
-            // }
             const float score = Eval::eval(options, pos, moves, depth, o_attacks);
             return SearchInfo(depth, depth, false, score, 1, 0, 0, {}, alpha, beta, true);
         }

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -284,7 +284,6 @@ int loop() {
         else if (cmd.size() > 0) std::cerr << "Unknown command: " << cmd << endl;
     }
 
-    delete options.hash_evaled;
-    delete options.hash_evals;
+    delete[] options.hash_table;
     return 0;
 }

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -183,7 +183,10 @@ int loop() {
     while (getline(cin, cmd)) {
         cmd = strip(cmd);
 
-        if (cmd == "quit") break;
+        if (cmd == "quit") {
+            searching = false;
+            break;
+        }
         else if (cmd == "clear") {
             string str;
             for (char i: {27, 91, 51, 74, 27, 91, 72, 27, 91, 50, 74}) str += string(1, i);

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -197,7 +197,7 @@ int loop() {
             cout << "id name Megalodon" << "\n";
             cout << "id author Megalodon Developers" << "\n";
 
-            cout << "option name Hash type spin default 16 min 1 max 65536" << "\n";
+            cout << "option name Hash type spin default 256 min 1 max 65536" << "\n";
             cout << "option name UseHashTable type check default false" << "\n";
 
             cout << "option name ABPassStart type spin default 5 min 1 max 100" << "\n";

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -198,7 +198,8 @@ int loop() {
             cout << "id author Megalodon Developers" << "\n";
 
             cout << "option name Hash type spin default 256 min 1 max 65536" << "\n";
-            cout << "option name UseHashTable type check default false" << "\n";
+            cout << "option name UseHashTable type check default true" << "\n";
+            cout << "option name HashStart type spin default 3 min 1 max 6" << "\n";
 
             cout << "option name ABPassStart type spin default 5 min 1 max 100" << "\n";
             cout << "option name ABPassMargin type spin default 500 min 0 max 10000" << "\n";
@@ -226,6 +227,7 @@ int loop() {
                 options.set_hash();
             }
             else if (name == "UseHashTable") options.UseHashTable = (value == "true");
+            else if (name == "HashStart") options.HashStart = std::stoi(value);
 
             else if (name == "ABPassStart") options.ABPassStart = std::stoi(value);
             else if (name == "ABPassMargin") options.ABPassMargin = std::stoi(value);


### PR DESCRIPTION
## Describe changes
Added move ordering. Orders moves from best to worst.
Options:
`Hash`: Hash table size (megabytes)
`UseHashTable`: Whether to do move ordering.
`HashStart`: Starting depth to order moves. Smaller = more pruning, larger = more accurate.

## Additional info
Not same results due to hash collisions.
Branch `move-order`: Reached depth 6 in 8.7 secs, 1.45 million nodes, 166k nps.
Branch `main`: Reached depth 6 in 21 secs, 4.7 million nodes, 223k nps.
