### PR TITLE
King Safety Evaluation

### DIFF
--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -100,7 +100,7 @@ namespace Eval {
         return (
             pawn_struct * 0.9 +
             knight      * 0.2 +
-            king        * 0.3 +
+            king        * 0.2 +
             space       * 1
         );
     }
@@ -109,7 +109,7 @@ namespace Eval {
         return (
             pawn_struct * 1.2 +
             knight      * 0.1 +
-            king        * 0.3 +
+            king        * 0.2 +
             space       * 0        // Space encourages pawns in the center, which discourages promotion.
         );
     }
@@ -305,8 +305,8 @@ namespace Eval {
 
         return (
             wdist-bdist +
-            shield * 2 +
-            attack
+            shield * 1.2 +
+            attack / 1.7
         );
     }
 

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -125,6 +125,10 @@ namespace Eval {
         return dist;
     }
 
+    char manhattan_dist(const char& x1, const char& y1, const char& x2, const char& y2) {
+        return abs(x1-x2) + abs(y1-y2);
+    }
+
 
     float pawn_structure(const U64& wp, const U64& bp) {
         // Values represent white - black
@@ -274,9 +278,35 @@ namespace Eval {
             }
         }
 
+        // Piece attacking and defending
+        float attack = 0;
+        //float defend = 0;
+        char wcnt = 0, bcnt = 0;
+        for (char x = 0; x < 8; x++) {
+            for (char y = 0; y < 8; y++) {
+                const char loc = (y<<3) + x;
+                const char wdist = manhattan_dist(x, y, w.x, w.y);
+                const char bdist = manhattan_dist(x, y, b.x, b.y);
+                if (bit(wpieces, loc)) {
+                    //defend += 16 - wdist;
+                    attack += 16 - bdist;
+                    wcnt++;
+                } else if (bit(bpieces, loc)) {
+                    //defend -= 16 - bdist;
+                    attack -= 16 - wdist;
+                    bcnt++;
+                }
+            }
+        }
+        if (wcnt+bcnt > 0) {
+            attack /= (wcnt+bcnt);
+            //defend /= (wcnt+bcnt);
+        }
+
         return (
             wdist-bdist +
-            shield * 2
+            shield * 2 +
+            attack
         );
     }
 

--- a/src/eval.hpp
+++ b/src/eval.hpp
@@ -48,6 +48,7 @@ namespace Eval {
     float end_game(const float&, const float&, const float&);
 
     char center_dist(const char&);
+    char manhattan_dist(const char&, const char&, const char&, const char&);
 
     float pawn_structure(const U64&, const U64&);
     float space(const U64&, const U64&);

--- a/src/eval.hpp
+++ b/src/eval.hpp
@@ -32,7 +32,7 @@ using std::vector;
 using std::string;
 
 namespace Eval {
-    constexpr int MIDGAME_LIM = 50;
+    constexpr int MIDGAME_LIM = 50;   // Limits of linear gradual eval in total material.
     constexpr int ENDGAME_LIM = 20;
     constexpr U64 INNER_CENTER = 103481868288ULL;
     constexpr U64 OUTER_CENTER = 66125924401152ULL;
@@ -52,7 +52,8 @@ namespace Eval {
     float pawn_structure(const U64&, const U64&);
     float space(const U64&, const U64&);
     float knights(const U64&, const U64&, const U64&, const U64&);
-    float kings(const U64&, const U64&);
+    float kings_mg(const U64&, const U64&, const U64&, const U64&, const U64&, const U64&);
+    float kings_eg(const U64&, const U64&);
 
     char center_dist(const char&);
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -36,7 +36,7 @@ MoveOrder::MoveOrder() {
 
 Options::Options() {
     Hash           = 256;
-    UseHashTable   = true;
+    UseHashTable   = false;
     HashStart      = 3;
 
     ABPassStart    = 5;

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -41,7 +41,7 @@ struct MoveOrder {
 class Options {
 /*
 Hash: type=spin, default=16, min=1, max=65536, hash table size (megabytes)
-UseHashTable: type=check, default=true, whether the engine should use hash table.
+UseHashTable: type=check, default=false, whether the engine should use hash table.
 HashStart: type=spin, default=3, min=1, max=6, starting depth to read and write into hash table.
 
 ABPassStart: type=spin, default=5, min=1, max=100, start depth where alpha and beta values are passed to next iteration.

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -198,7 +198,7 @@ int loop() {
             cout << "id author Megalodon Developers" << "\n";
 
             cout << "option name Hash type spin default 256 min 1 max 65536" << "\n";
-            cout << "option name UseHashTable type check default true" << "\n";
+            cout << "option name UseHashTable type check default false" << "\n";
             cout << "option name HashStart type spin default 3 min 1 max 6" << "\n";
 
             cout << "option name ABPassStart type spin default 5 min 1 max 100" << "\n";


### PR DESCRIPTION
## Describe changes
King safety evaluation:
* Favors pawns near the king
* Favors moving pieces near the opponent's king
* There is a commented parameter to bring pieces near your own king to defend, but that just undoes attacking.

## Testing info
Tested with fen positions and playing against it.
