### PR TITLE
Transposition Table

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -58,7 +58,7 @@ Options::Options() {
 
 void Options::set_hash() {
     delete[] hash_table;
-    hash_size = Hash * 209000;
+    hash_size = Hash * HASH_FACTOR;
     hash_table = new Transposition[hash_size];
     clear_hash();
 }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -60,6 +60,7 @@ void Options::set_hash() {
     delete[] hash_table;
     hash_size = Hash * 209000;
     hash_table = new Transposition[hash_size];
+    clear_hash();
 }
 
 void Options::clear_hash() {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -22,6 +22,8 @@
 #include <string>
 #include "options.hpp"
 
+#define HASH_FACTOR  209000
+
 using std::cin;
 using std::cout;
 using std::endl;
@@ -30,7 +32,6 @@ using std::string;
 
 
 Transposition::Transposition() {
-    computed = false;
 }
 
 
@@ -65,6 +66,6 @@ void Options::set_hash() {
 
 void Options::clear_hash() {
     for (auto i = 0; i < hash_size; i++) {
-        hash_table[i].computed = false;
+        hash_table[i].depth = 0;
     }
 }

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -39,7 +39,7 @@ struct Transposition {
 
 class Options {
 /*
-Hash: type=spin, default=16, min=1, max=65536, hash table size (megabytes)
+Hash: type=spin, default=256, min=1, max=65536, hash table size (megabytes)
 UseHashTable: type=check, default=false, whether the engine should use hash table.
 HashStart: type=spin, default=5, min=1, max=8, starting depth to read and write into hash table.
 

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -24,8 +24,6 @@
 #include <string>
 #include "bitboard.hpp"
 
-#define HASH_FACTOR  209000
-
 using std::cin;
 using std::cout;
 using std::endl;
@@ -35,7 +33,7 @@ using std::string;
 struct Transposition {
     Transposition();
 
-    bool computed;
+    char depth;
     Move best;
 };
 

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -24,6 +24,8 @@
 #include <string>
 #include "bitboard.hpp"
 
+#define HASH_FACTOR  209000
+
 using std::cin;
 using std::cout;
 using std::endl;
@@ -63,7 +65,7 @@ public:
     void clear_hash();
 
     Transposition* hash_table;
-    int hash_size;
+    U64 hash_size;
 
     int Hash;
     bool UseHashTable;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -118,8 +118,8 @@ namespace Search {
         float best_eval = pos.turn ? MIN : MAX;
         bool full = true;
         for (auto i = 0; i < moves.size(); i++) {
-            if (depth > 1) {
-                if (get_time() >= endtime || !searching) {
+            if (depth >= 3) {
+                if ((get_time() >= endtime) || !searching) {
                     full = false;
                     break;
                 }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -39,8 +39,8 @@ using std::string;
 SearchInfo::SearchInfo() {
 }
 
-SearchInfo::SearchInfo(int _depth, int _seldepth, float _score, U64 _nodes, int _nps,
-        double _time, vector<Move> _pv, float _alpha, float _beta, bool _full) {
+SearchInfo::SearchInfo(const int& _depth, const int& _seldepth, const float& _score, const U64& _nodes, const int& _nps,
+        const double& _time, const vector<Move>& _pv, const float& _alpha, const float& _beta, const bool& _full) {
     depth = _depth;
     seldepth = _seldepth;
     score = _score;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -150,7 +150,7 @@ namespace Search {
                     pv = result.pv;
                 }
                 if (result.score > alpha) alpha = result.score;
-                if (beta <= alpha) break;
+                if (beta < alpha) break;
             } else {
                 if (result.score < best_eval) {
                     best_ind = i;
@@ -158,7 +158,7 @@ namespace Search {
                     pv = result.pv;
                 }
                 if (result.score < beta) beta = result.score;
-                if (beta <= alpha) break;
+                if (beta < alpha) break;
             }
         }
         pv.insert(pv.begin(), moves[best_ind]);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -101,7 +101,7 @@ namespace Search {
         const U64 o_attacks = Bitboard::attacked(pos, !pos.turn);
         vector<Move> moves = Bitboard::legal_moves(pos, o_attacks);
 
-        const bool use_hash = (depth >= 3);
+        const bool use_hash = false;//(depth >= 3);
         const U64 idx = use_hash ? Hash::hash(pos) % options.hash_size : 0;
         Transposition& entry = options.hash_table[idx];
         if (use_hash && entry.computed) moves.insert(moves.begin(), entry.best);
@@ -142,7 +142,7 @@ namespace Search {
                     pv = result.pv;
                 }
                 if (result.score > alpha) alpha = result.score;
-                if (beta < alpha) break;
+                if (beta <= alpha) break;
             } else {
                 if (result.score < best_eval) {
                     best_ind = i;
@@ -150,7 +150,7 @@ namespace Search {
                     pv = result.pv;
                 }
                 if (result.score < beta) beta = result.score;
-                if (beta < alpha) break;
+                if (beta <= alpha) break;
             }
         }
         pv.insert(pv.begin(), moves[best_ind]);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -180,6 +180,7 @@ namespace Search {
 
         SearchInfo result;
         U64 hash_filled = 0;
+        U64 nodes = 0;
         const double start = get_time();
         const double end = start + movetime;
 
@@ -188,8 +189,10 @@ namespace Search {
 
             SearchInfo curr_result = dfs(options, pos, d, 0, MIN, MAX, true, end, searching, hash_filled);
             const double elapse = get_time() - start;
+            nodes += curr_result.nodes;
 
             curr_result.time = elapse;
+            curr_result.nodes = nodes;
             curr_result.nps = curr_result.nodes / (elapse+0.001);
             curr_result.hashfull = 1000 * hash_filled / options.hash_size;
             if (!pos.turn) curr_result.score *= -1;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -108,7 +108,7 @@ namespace Search {
 
         const U64 idx = Hash::hash(pos) % options.hash_size;
         Transposition& entry = options.hash_table[idx];
-        if (entry.computed) moves.insert(moves.begin(), entry.best);
+        if (entry.depth > 0) moves.insert(moves.begin(), entry.best);
 
         U64 nodes = 1;
         vector<Move> pv;
@@ -123,7 +123,7 @@ namespace Search {
                     break;
                 }
             }
-            if ((i != 0) && entry.computed) {
+            if ((i != 0) && (entry.depth > 0)) {  // Don't search best move twice
                 const Move& best = entry.best;
                 const Move& curr = moves[i];
                 if ((best.from == curr.from) && (best.to == curr.to) && (best.is_promo == curr.is_promo) &&
@@ -160,9 +160,9 @@ namespace Search {
         }
         pv.insert(pv.begin(), moves[best_ind]);
 
-        if (!entry.computed) {
-            entry.computed = true;
+        if (depth > entry.depth) {
             entry.best = moves[best_ind];
+            entry.depth = depth;
             hash_filled++;
         }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -101,7 +101,7 @@ namespace Search {
         const U64 o_attacks = Bitboard::attacked(pos, !pos.turn);
         vector<Move> moves = Bitboard::legal_moves(pos, o_attacks);
 
-        const bool use_hash = (depth >= 2);
+        const bool use_hash = (depth >= 3);
         const U64 idx = use_hash ? Hash::hash(pos) % options.hash_size : 0;
         Transposition& entry = options.hash_table[idx];
         if (use_hash && entry.computed) moves.insert(moves.begin(), entry.best);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -101,7 +101,7 @@ namespace Search {
         const U64 o_attacks = Bitboard::attacked(pos, !pos.turn);
         vector<Move> moves = Bitboard::legal_moves(pos, o_attacks);
 
-        const bool use_hash = (depth >= 3);
+        const bool use_hash = (depth >= 2);
         const U64 idx = use_hash ? Hash::hash(pos) % options.hash_size : 0;
         Transposition& entry = options.hash_table[idx];
         if (use_hash && entry.computed) moves.insert(moves.begin(), entry.best);

--- a/src/search.hpp
+++ b/src/search.hpp
@@ -33,7 +33,7 @@ using std::string;
 
 struct SearchInfo {
     SearchInfo();
-    SearchInfo(const int&, const int&, const float&, const U64&, const int&, const double&, const vector<Move>&,
+    SearchInfo(const int&, const int&, const float&, const U64&, const int&, const int&, const double&, const vector<Move>&,
         const float&, const float&, const bool&);
     string as_string();
     bool is_mate();
@@ -43,6 +43,7 @@ struct SearchInfo {
     float score;
     U64 nodes;
     int nps;
+    int hashfull;
     double time;
     vector<Move> pv;
 

--- a/src/search.hpp
+++ b/src/search.hpp
@@ -33,7 +33,8 @@ using std::string;
 
 struct SearchInfo {
     SearchInfo();
-    SearchInfo(int, int, float, U64, int, double, vector<Move>, float, float, bool);
+    SearchInfo(const int&, const int&, const float&, const U64&, const int&, const double&, const vector<Move>&,
+        const float&, const float&, const bool&);
     string as_string();
     bool is_mate();
 


### PR DESCRIPTION
## Describe changes
Added transposition table.
Stores the best move and searches that first next time.
Number of entries = `size * 209000`, size = megabytes.
Only stores positions with 1 depth search in front. Allows more total nodes without collison.

## Testing info
Please look at comments for testing info.
