### PR TITLE
Hash Table Compression

### DIFF
--- a/src/bitboard.hpp
+++ b/src/bitboard.hpp
@@ -38,7 +38,7 @@ struct Move {
     char from;
     char to;
     bool is_promo;
-    char promo;
+    char promo;  // 0, 1, 2, 3
 };
 
 struct Position {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -22,7 +22,7 @@
 #include <string>
 #include "options.hpp"
 
-#define HASH_FACTOR  209000
+#define HASH_FACTOR  348000
 
 using std::cin;
 using std::cout;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -43,7 +43,7 @@ Options::Options() {
     MoveTimeMult   = 100;
     UseEndgame     = false;
     LMRFactor      = 0;
-    QuickMove      = true;
+    QuickMove      = false;
 
     EvalMaterial   = 1;
     EvalPawnStruct = 1;

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -34,7 +34,8 @@ struct Transposition {
     Transposition();
 
     char depth;
-    Move best;
+    char from;  // First six bits = square, last two = promo piece
+    char to;    // First six bits = square, seventh = is_promo
 };
 
 class Options {

--- a/src/options.hpp
+++ b/src/options.hpp
@@ -46,7 +46,7 @@ HashStart: type=spin, default=5, min=1, max=8, starting depth to read and write 
 MoveTimeMult: type=spin, default=100, min=10, max=1000, multiplier (percent) of move time.
 UseEndgame: type=check, default=false, whether to use endgame algorithms.
 LMRFactor: type=spin, default=0, min=0, max=100, percent of lowest branches at lower depth. ONLY WORKS IF USING HASH TABLE
-QuickMove: type=check, default=true, whether to move immediately when there is only one legal move (output will be missing eval info).
+QuickMove: type=check, default=false, whether to move immediately when there is only one legal move (output will be missing eval info).
 
 EvalMaterial: type=spin, default=100, min=0, max=1000, weight (percent) of material eval.
 EvalSpace: type=spin, default=100, min=0, max=1000, weight (percent) of space eval.

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -161,9 +161,9 @@ namespace Search {
         pv.insert(pv.begin(), moves[best_ind]);
 
         if (depth > entry.depth) {
+            if (entry.depth == 0) hash_filled++;
             entry.best = moves[best_ind];
             entry.depth = depth;
-            hash_filled++;
         }
 
         return SearchInfo(depth, depth, best_eval, nodes, 0, 0, 0, pv, alpha, beta, full);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -83,16 +83,11 @@ bool SearchInfo::is_mate() {
 
 
 namespace Search {
-    float moves_left(const Options& options, const Position& pos) {
-        float abs_left = 55 - pos.move_cnt;
-        if (abs_left < 5) abs_left = 5;
-        return abs_left;
-    }
-
     float move_time(const Options& options, const Position& pos, const float& time, const float& inc) {
-        const float moves = moves_left(options, pos);
+        const int moves = std::max(55-pos.move_cnt, 5);
         const float time_left = time + inc*moves;
-        return time_left / moves;
+        const float move_time = time_left / moves;
+        return std::min(move_time, time/2);
     }
 
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -101,9 +101,11 @@ namespace Search {
             return SearchInfo(depth, depth, score, 1, 0, 0, 0, {}, alpha, beta, true);
         }
 
+        // Parse and store best move
         const U64 idx = Hash::hash(pos) % options.hash_size;
         Transposition& entry = options.hash_table[idx];
-        if (entry.depth > 0) moves.insert(moves.begin(), entry.best);
+        const Move best(entry.from&63, entry.to&63, entry.to&64, (entry.from&192)>>6);
+        if (entry.depth > 0) moves.insert(moves.begin(), best);
 
         U64 nodes = 1;
         vector<Move> pv;
@@ -119,7 +121,6 @@ namespace Search {
                 }
             }
             if ((i != 0) && (entry.depth > 0)) {  // Don't search best move twice
-                const Move& best = entry.best;
                 const Move& curr = moves[i];
                 if ((best.from == curr.from) && (best.to == curr.to) && (best.is_promo == curr.is_promo) &&
                         (best.promo == curr.promo)) continue;
@@ -157,7 +158,10 @@ namespace Search {
 
         if (depth > entry.depth) {
             if (entry.depth == 0) hash_filled++;
-            entry.best = moves[best_ind];
+
+            const Move& best_move = moves[best_ind];
+            entry.from = best_move.from + (best_move.promo<<6);
+            entry.to = best_move.to + (best_move.is_promo<<6);
             entry.depth = depth;
         }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -206,9 +206,9 @@ namespace Search {
             }
             if (curr_result.is_mate() && (curr_result.score > 0) && !infinite) break;
 
-            if (stop_early && ((elapse/movetime) >= 0.6)) {    // Won't finish next depth so no point
-                break;
-            }
+            // if (stop_early && ((elapse/movetime) >= 0.6)) {    // Won't finish next depth so no point
+            //     break;
+            // }
         }
 
         return result;

--- a/src/search.hpp
+++ b/src/search.hpp
@@ -56,7 +56,6 @@ namespace Search {
     constexpr float MAX = 10000;
     constexpr float MIN = -10000;
 
-    float moves_left(const Options&, const Position&);
     float move_time(const Options&, const Position&, const float&, const float&);
 
     SearchInfo search(const Options&, const Position&, const int&, const double&, const bool&,

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -202,7 +202,7 @@ int loop() {
             cout << "option name MoveTimeMult type spin default 100 min 10 max 1000" << "\n";
             cout << "option name UseEndgame type check default false" << "\n";
             cout << "option name LMRFactor type spin default 0 min 0 max 100" << "\n";
-            cout << "option name QuickMove type check default true" << "\n";
+            cout << "option name QuickMove type check default false" << "\n";
 
             cout << "option name EvalMaterial type spin default 100 min 0 max 1000" << "\n";
             cout << "option name EvalPawnStruct type spin default 100 min 0 max 1000" << "\n";


### PR DESCRIPTION
## Describe changes
Added compression in hash table entry.
Used to be `char, char, char, bool char`. Now is `char, char, char`
60% capacity increase, able to store 89 million positions at default 256 MB.

## Testing info
This branch was extended from `patrick-patch-1`, so tests are relative to it.
Same pv at depth 6 search. No visible slow down. A little less nodes, most likely due to less collisions.
Same bench result.
