### PR TITLE
Pseudo random gen

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,6 +22,7 @@
 #include <string>
 #include "uci.hpp"
 #include "bitboard.hpp"
+#include "random.hpp"
 #include "hash.hpp"
 #include "eval.hpp"
 #include "search.hpp"
@@ -97,7 +98,7 @@ void bench() {
 
 int main(const int argc, const char* argv[]) {
     cout << std::fixed;
-    srand(1234);
+    Random::set_seed(1234);
 
     if (argc >= 2) {
         if      (argv[1] == string("--version")) cout << VERSION << endl;

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -30,7 +30,7 @@ using std::string;
 
 
 namespace Random {
-    unsigned long long curr = get_time();
+    unsigned long long curr = 1234;
 
     void set_seed(unsigned long long s) {
         curr = s;

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -26,3 +26,14 @@ using std::cout;
 using std::endl;
 using std::vector;
 using std::string;
+
+
+namespace Random {
+    void set_seed(unsigned long long s) {
+        ;
+    }
+
+    auto random() {
+        ;
+    }
+}

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -1,0 +1,28 @@
+//
+//  Megalodon
+//  UCI chess engine
+//  Copyright the Megalodon developers
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+#include <iostream>
+#include <vector>
+#include <string>
+
+using std::cin;
+using std::cout;
+using std::endl;
+using std::vector;
+using std::string;

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -20,6 +20,7 @@
 #include <iostream>
 #include <vector>
 #include <string>
+#include "utils.hpp"
 
 using std::cin;
 using std::cout;
@@ -29,7 +30,7 @@ using std::string;
 
 
 namespace Random {
-    unsigned long long curr = 1;
+    unsigned long long curr = get_time();
 
     void set_seed(unsigned long long s) {
         curr = s;

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -33,11 +33,12 @@ namespace Random {
 
     void set_seed(unsigned long long s) {
         curr = s;
-        if (curr == 0) curr++;
+        if (curr == 0) curr = 1;
     }
 
     unsigned long long random() {
         curr *= 16807;
+        if (curr == 0) curr = 1;
         return curr;
     }
 }

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -29,11 +29,15 @@ using std::string;
 
 
 namespace Random {
+    unsigned long long curr = 1;
+
     void set_seed(unsigned long long s) {
-        ;
+        curr = s;
+        if (curr == 0) curr++;
     }
 
-    auto random() {
-        ;
+    unsigned long long random() {
+        curr *= 16807;
+        return curr;
     }
 }

--- a/src/random.hpp
+++ b/src/random.hpp
@@ -1,0 +1,28 @@
+//
+//  Megalodon
+//  UCI chess engine
+//  Copyright the Megalodon developers
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+#include <iostream>
+#include <vector>
+#include <string>
+
+using std::cin;
+using std::cout;
+using std::endl;
+using std::vector;
+using std::string;

--- a/src/random.hpp
+++ b/src/random.hpp
@@ -26,3 +26,9 @@ using std::cout;
 using std::endl;
 using std::vector;
 using std::string;
+
+
+namespace Random {
+    void set_seed(unsigned long long);
+    auto random();
+}

--- a/src/random.hpp
+++ b/src/random.hpp
@@ -30,5 +30,5 @@ using std::string;
 
 namespace Random {
     void set_seed(unsigned long long);
-    auto random();
+    unsigned long long random();
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -23,6 +23,7 @@
 #include <string>
 #include <chrono>
 #include "bitboard.hpp"
+#include "random.hpp"
 #include "utils.hpp"
 
 using std::cin;
@@ -106,9 +107,9 @@ vector<Position> flatten(const vector<vector<Position>>& vec) {
 
 
 string rand_choice(const vector<string>& choices) {
-    return choices[rand()%choices.size()];
+    return choices[Random::random()%choices.size()];
 }
 
 U64 randull() {
-    return ((U64)rand()) + (((U64)rand())<<32);
+    return ((U64)Random::random()) + (((U64)Random::random())<<32);
 }


### PR DESCRIPTION
## Describe changes
Add a pseudo-random number generator. Random numbers are mainly needed for hashing, and they don't have to be very good. They just need to cover a wide range and have a roughly even distribution. Fixes #79 

## Testing info
Builtin C++ `rand()`: Multiple collisions at 1M random number generations.
New `Random::random()`: No collisions at 100M random number generations.

More testing details [here](https://github.com/megalodon-chess/megalodon/pull/83#issuecomment-827263582).